### PR TITLE
Make results count work no matter if api returns int or str

### DIFF
--- a/resce.py
+++ b/resce.py
@@ -464,7 +464,7 @@ def srrdbidentify(crc):
         if len(str(sys.exc_info()[1])) > 0:
             print sys.exc_info()[1]
 
-    if not response or response['resultsCount'] != '1':
+    if not response or int(response['resultsCount']) < 1:
         print 'not found.'
         return False
 


### PR DESCRIPTION
api seems to sometimes return str and sometimes int.